### PR TITLE
PlaySound 7.3 PTR/7.2.5 live cross-compatibility

### DIFF
--- a/PhanxConfig-Dropdown.lua
+++ b/PhanxConfig-Dropdown.lua
@@ -10,7 +10,7 @@
 	credits line -- any modified versions must be renamed to avoid conflicts.
 ----------------------------------------------------------------------]]
 
-local MINOR_VERSION = 20170723
+local MINOR_VERSION = 20170828
 
 local lib, oldminor = LibStub:NewLibrary("PhanxConfig-Dropdown", MINOR_VERSION)
 if not lib then return end
@@ -19,14 +19,9 @@ lib.listFrames = lib.listFrames or {}
 
 local MAX_LIST_SIZE = 15
 
-local S_UChatScrollButton,S_igMainMenuOptionCheckBoxOn
-if SOUNDKIT then
-	S_UChatScrollButton = SOUNDKIT.U_CHAT_SCROLL_BUTTON
-	S_igMainMenuOptionCheckBoxOn = SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON
-else
-	S_UChatScrollButton = 'UChatScrollButton'
-	S_igMainMenuOptionCheckBoxOn = 'igMainMenuOptionCheckBoxOn'
-end
+local S_UChatScrollButton = 1115
+local S_igMainMenuOptionCheckBoxOn = 856
+local PlaySound = PlaySoundKitID or PlaySound
 
 ------------------------------------------------------------------------
 

--- a/PhanxConfig-Dropdown.lua
+++ b/PhanxConfig-Dropdown.lua
@@ -10,7 +10,7 @@
 	credits line -- any modified versions must be renamed to avoid conflicts.
 ----------------------------------------------------------------------]]
 
-local MINOR_VERSION = 20160802
+local MINOR_VERSION = 20170723
 
 local lib, oldminor = LibStub:NewLibrary("PhanxConfig-Dropdown", MINOR_VERSION)
 if not lib then return end
@@ -18,6 +18,15 @@ if not lib then return end
 lib.listFrames = lib.listFrames or {}
 
 local MAX_LIST_SIZE = 15
+
+local S_UChatScrollButton,S_igMainMenuOptionCheckBoxOn
+if SOUNDKIT then
+	S_UChatScrollButton = SOUNDKIT.U_CHAT_SCROLL_BUTTON
+	S_igMainMenuOptionCheckBoxOn = SOUNDKIT.IG_MAINMENU_OPTION_CHECKBOX_ON
+else
+	S_UChatScrollButton = 'UChatScrollButton'
+	S_igMainMenuOptionCheckBoxOn = 'igMainMenuOptionCheckBoxOn'
+end
 
 ------------------------------------------------------------------------
 
@@ -101,7 +110,7 @@ local function ListButton_OnClick(self)
 		callback(dropdown, self.value, self:GetText())
 	end
 
-	PlaySound("UChatScrollButton")
+	PlaySound(S_UChatScrollButton)
 
 	if dropdown.keepShownOnClick then
 		OpenDropdown(dropdown)
@@ -294,7 +303,7 @@ end
 ------------------------------------------------------------------------
 
 local function Button_OnClick(self)
-	PlaySound("igMainMenuOptionCheckBoxOn")
+	PlaySound(S_igMainMenuOptionCheckBoxOn)
 
 	local dropdown = self:GetParent()
 	OpenDropdown(dropdown)


### PR DESCRIPTION
/wave

It's currently necessary to use soundkit IDs on the 7.3 PTR, however the lookup table doesn't exist on live, so we can do something like this as a bandaid.

Whether or not they will actually break strings once 7.3 is live, who knows.

(Tested and working on both versions).