### PR TITLE
fix CloseDropDownMenus() closing active dropdowns prematurely (#2) and backdrop API for patch 9.0+

### DIFF
--- a/PhanxConfig-Dropdown.lua
+++ b/PhanxConfig-Dropdown.lua
@@ -10,7 +10,7 @@
 	credits line -- any modified versions must be renamed to avoid conflicts.
 ----------------------------------------------------------------------]]
 
-local MINOR_VERSION = 20170904
+local MINOR_VERSION = 20200219
 
 local lib, oldminor = LibStub:NewLibrary("PhanxConfig-Dropdown", MINOR_VERSION)
 if not lib then return end
@@ -30,12 +30,17 @@ local function OpenDropdown(dropdown)
 		dropdown.list = list
 	end
 
+	for i = 1, #lib.listFrames do
+		lib.listFrames[i].isActive = false
+	end
+
 	local show = not list:IsShown()
 	CloseDropDownMenus()
 
 	if show then
 		list:Show()
 		list:Raise()
+		list.isActive = true
 		local selectedIndex
 		local items, selected = dropdown.items, dropdown.selected
 		for i = 1, #items do
@@ -54,7 +59,9 @@ end
 
 local function CloseDropdowns(_, _, dropDownFrame, _, _, _, _, clickedButton)
 	for i = 1, #lib.listFrames do
-		lib.listFrames[i]:Hide()
+		if not lib.listFrames[i].isActive then
+			lib.listFrames[i]:Hide()
+		end
 	end
 end
 
@@ -83,6 +90,7 @@ end
 
 local function Frame_OnHide(self)
 	if self.list then
+		self.list.isActive = false
 		self.list:Hide()
 	end
 end
@@ -92,6 +100,7 @@ end
 local function ListButton_OnClick(self)
 	local dropdown = self:GetParent():GetParent()
 	dropdown.selected = self.value
+	dropdown.list.isActive = false
 	dropdown.list:Hide()
 
 	dropdown.valueText:SetText(self:GetText() or self.value)

--- a/PhanxConfig-Dropdown.lua
+++ b/PhanxConfig-Dropdown.lua
@@ -10,7 +10,7 @@
 	credits line -- any modified versions must be renamed to avoid conflicts.
 ----------------------------------------------------------------------]]
 
-local MINOR_VERSION = 20200219
+local MINOR_VERSION = 20201001
 
 local lib, oldminor = LibStub:NewLibrary("PhanxConfig-Dropdown", MINOR_VERSION)
 if not lib then return end
@@ -256,7 +256,7 @@ function CreateList(dropdown) -- local
 
 	id = id + 1
 
-	local list = CreateFrame("Button", "PhanxConfigDropdown" .. id, dropdown)
+	local list = CreateFrame("Button", "PhanxConfigDropdown" .. id, dropdown, BackdropTemplateMixin and "BackdropTemplate")
 	list:SetFrameStrata("DIALOG")
 	list:SetToplevel(true)
 	list:Hide()


### PR DESCRIPTION
Patch 8.3.0 made a change that calls `CloseDropDownMenus` every time you click something on your screen. This causes the phanx-dropdown(s) to be closed right before you click a dropdown entry and thus `ListButton_OnClick` will never be triggered and no entry will be selected.

This PR fixes that issue by checking for an `isActive` flag before trying to close any phanx dropdowns.  (Will be `true` for the most recently opened & visible dropdown)

**Edit:** Seems the author is no longer active on Github at all. For anyone reading, i'm hosting a fork of this project [here](https://github.com/wardz/WardzConfigDropdown-1.0/) for now.